### PR TITLE
Draft of how to use proxies in a client context for signaling

### DIFF
--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
+
 namespace Microsoft.Azure.WebJobs
 {
     /// <summary>
@@ -9,15 +12,26 @@ namespace Microsoft.Azure.WebJobs
     public static class DurableEntityProxyExtensions
     {
         /// <summary>
-        /// Create Entity Proxy.
+        /// Signals an entity to perform an operation.
         /// </summary>
-        /// <param name="client">orchestration client.</param>
-        /// <param name="entityId">Entity id.</param>
         /// <typeparam name="TEntityInterface">Entity interface.</typeparam>
-        /// <returns>Entity proxy.</returns>
-        public static TEntityInterface CreateEntityProxy<TEntityInterface>(this IDurableOrchestrationClient client, EntityId entityId)
+        /// <param name="client">orchestration client.</param>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="operation">A delegate that performs the desired operation on the entity.</param>
+        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        public static Task SignalEntityAsync<TEntityInterface>(this IDurableOrchestrationClient client, EntityId entityId, Action<TEntityInterface> operation)
         {
-            return EntityProxyFactory.Create<TEntityInterface>(new OrchestrationClientProxy(client), entityId);
+            var proxyContext = new OrchestrationClientProxy(client);
+            var proxy = EntityProxyFactory.Create<TEntityInterface>(proxyContext, entityId);
+
+            operation(proxy);
+
+            if (proxyContext.SignalTask == null)
+            {
+                throw new InvalidOperationException("The operation action must perform an operation on the entity");
+            }
+
+            return proxyContext.SignalTask;
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationClientProxy.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationClientProxy.cs
@@ -15,19 +15,33 @@ namespace Microsoft.Azure.WebJobs
             this.client = client;
         }
 
+        internal Task SignalTask { get; private set; }
+
         public Task CallAsync(EntityId entityId, string operationName, object operationInput)
         {
-            throw new NotSupportedException();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+            return Task.CompletedTask;
         }
 
         public Task<TResult> CallAsync<TResult>(EntityId entityId, string operationName, object operationInput)
         {
-            throw new NotSupportedException();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+            return Task.FromResult<TResult>(default(TResult));
         }
 
         public void Signal(EntityId entityId, string operationName, object operationInput)
         {
-            this.client.SignalEntityAsync(entityId, operationName, operationInput).GetAwaiter().GetResult();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+        }
+
+        private void SignalAndStoreTask(EntityId entityId, string operationName, object operationInput)
+        {
+            if (this.SignalTask != null)
+            {
+                throw new InvalidOperationException("The operation action must not perform more than one operation");
+            }
+
+            this.SignalTask = this.client.SignalEntityAsync(entityId, operationName, operationInput);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2270,14 +2270,15 @@
             Extension methods.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,Microsoft.Azure.WebJobs.EntityId)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,Microsoft.Azure.WebJobs.EntityId,System.Action{``0})">
             <summary>
-            Create Entity Proxy.
+            Signals an entity to perform an operation.
             </summary>
-            <param name="client">orchestration client.</param>
-            <param name="entityId">Entity id.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
-            <returns>Entity proxy.</returns>
+            <param name="client">orchestration client.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.EntityId)">
             <summary>


### PR DESCRIPTION
This is the solution I wanted to try out for how to handle signaling on the client.

- Proxies in orchestration and entity contexts are unchanged from the current solution.
- On clients, we do not support a `CreateProxy` method; instead, we are using a form of `SignalEntityAsync`:

```csharp
await client.SignalEntityAsync<ICounterEntity>(proxy => proxy.Set(50));
```
