### PR TITLE
Entity proxy samples

### DIFF
--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserChirps.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserChirps.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Chirper.Service
+{
+    interface IUserChirps
+    {
+        void Add(Chirp chirp);
+
+        void Remove(DateTime timestamp);
+
+        Task<List<Chirp>> Get();
+    }
+}

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserChirps.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserChirps.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Chirper.Service
 {
-    interface IUserChirps
+    public interface IUserChirps
     {
         void Add(Chirp chirp);
 

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserFollows.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/IUserFollows.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Chirper.Service
+{
+    public interface IUserFollows
+    {
+        void Add(string user);
+
+        void Remove(string user);
+
+        Task<List<string>> Get();
+    }
+}

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/UserChirps.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/UserChirps.cs
@@ -18,7 +18,7 @@ namespace Chirper.Service
     // The entity key is the userId.
 
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    public class UserChirps
+    public class UserChirps : IUserChirps
     {
         [JsonProperty]
         public List<Chirp> Chirps { get; set; } = new List<Chirp>();
@@ -33,9 +33,9 @@ namespace Chirper.Service
             Chirps.RemoveAll(chirp => chirp.Timestamp == timestamp);
         }
 
-        public List<Chirp> Get()
+        public Task<List<Chirp>> Get()
         {
-            return Chirps;
+            return Task.FromResult(Chirps);
         }
 
         // Boilerplate (entry point for the functions runtime)

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/UserFollows.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Entities/UserFollows.cs
@@ -17,7 +17,7 @@ namespace Chirper.Service
     // The entity key is the userId.
 
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    public class UserFollows
+    public class UserFollows : IUserFollows
     {
         [JsonProperty]
         public List<string> FollowedUsers { get; set; }  = new List<string>();
@@ -32,9 +32,9 @@ namespace Chirper.Service
             FollowedUsers.Remove(user);
         }
 
-        public List<string> Get()
+        public Task<List<string>> Get()
         {
-            return FollowedUsers;
+            return Task.FromResult(FollowedUsers);
         }
 
         // Boilerplate (entry point for the functions runtime)

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/Orchestrations/GetTimeline.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/Orchestrations/GetTimeline.cs
@@ -23,15 +23,14 @@ namespace Chirper.Service
             var userId = context.GetInput<string>();
 
             // call the UserFollows entity to figure out whose chirps should be included
-            var followedUsers = await context.CallEntityAsync<List<string>>(
-                new EntityId(nameof(UserFollows), userId), 
-                nameof(UserFollows.Get));
+            var userFollowsProxy = context.CreateEntityProxy<IUserFollows>(new EntityId(nameof(UserFollows), userId));
+            var followedUsers = await userFollowsProxy.Get();
 
             // in parallel, collect all the chirps
             var tasks = followedUsers
-                    .Select(id => context.CallEntityAsync<List<Chirp>>(
-                        new EntityId(nameof(UserChirps), id),
-                        nameof(UserChirps.Get)))
+                    .Select(id => context
+                        .CreateEntityProxy<IUserChirps>(new EntityId(nameof(UserChirps), id))
+                        .Get())
                     .ToList();
 
             await Task.WhenAll(tasks);

--- a/samples/v2/entitites-csharp/Chirper/Chirper.Service/PublicRest/HttpSurface.cs
+++ b/samples/v2/entitites-csharp/Chirper/Chirper.Service/PublicRest/HttpSurface.cs
@@ -61,7 +61,7 @@ namespace Chirper.Service
                 Timestamp = DateTime.UtcNow,
                 Content = await req.Content.ReadAsStringAsync(),
             };
-            await client.SignalEntityAsync(target, nameof(UserChirps.Add), chirp);
+            await client.SignalEntityAsync<IUserChirps>(target, x => x.Add(chirp));
             return req.CreateResponse(HttpStatusCode.Accepted, chirp);
         }
 
@@ -75,7 +75,7 @@ namespace Chirper.Service
         {
             Authenticate(req, userId);
             var target = new EntityId(nameof(UserChirps), userId);
-            await client.SignalEntityAsync(target, nameof(UserChirps.Remove), timestamp);
+            await client.SignalEntityAsync<IUserChirps>(target, x => x.Remove(timestamp));
             return req.CreateResponse(HttpStatusCode.Accepted);
         }
 
@@ -88,7 +88,6 @@ namespace Chirper.Service
         {
             Authenticate(req, userId);
             var target = new EntityId(nameof(UserFollows), userId);
-            await client.SignalEntityAsync(target, nameof(UserFollows.Get));
             var follows = await client.ReadEntityStateAsync<UserFollows>(target);
             return follows.EntityExists
                     ? req.CreateResponse(HttpStatusCode.OK, follows.EntityState.FollowedUsers)
@@ -105,7 +104,7 @@ namespace Chirper.Service
         {
             Authenticate(req, userId);
             var target = new EntityId(nameof(UserFollows), userId);
-            await client.SignalEntityAsync(target, nameof(UserFollows.Add), userId2);
+            await client.SignalEntityAsync<IUserFollows>(target, x => x.Add(userId2));
             return req.CreateResponse(HttpStatusCode.Accepted);
         }
 
@@ -120,7 +119,7 @@ namespace Chirper.Service
             Authenticate(req, userId);
             var content = await req.Content.ReadAsAsync<string>();
             var target = new EntityId(nameof(UserFollows), userId);
-            await client.SignalEntityAsync(target, nameof(UserFollows.Remove), userId2);
+            await client.SignalEntityAsync<IUserFollows>(target, x => x.Remove(userId2));
             return req.CreateResponse(HttpStatusCode.Accepted);
         }
 

--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/IRegionEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/IRegionEntity.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RideSharing
+{
+    public interface IRegionEntity
+    {
+        Task<string[]> GetAvailableDrivers();
+
+        Task<string[]> GetAvailableRiders();
+
+        void AddUser(string user);
+
+        void RemoveUser(string user);
+    }
+}

--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/IUserEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/IUserEntity.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RideSharing
+{
+    public interface IUserEntity
+    {
+        Task SetLocation(int? newLocation);
+
+        Task<UserEntity> GetState();
+
+        Task SetRide(RideInfo rideInfo);
+
+        void ClearRide(Guid rideId);
+    }
+}

--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/RegionEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/RegionEntity.cs
@@ -19,7 +19,7 @@ namespace RideSharing
     // the user entities send add-user / remove-user signals whenever they change
     // their region.
     [JsonObject(MemberSerialization.OptIn)]
-    public class RegionEntity
+    public class RegionEntity : IRegionEntity
     {
         [JsonProperty]
         public HashSet<string> Users { get; set; } = new HashSet<string>();
@@ -41,14 +41,14 @@ namespace RideSharing
             Users.Remove(user);
         }
 
-        public string[] GetAvailableDrivers()
+        public Task<string[]> GetAvailableDrivers()
         {
-            return Users.Where(id => id.StartsWith("D")).ToArray();
+            return Task.FromResult(Users.Where(id => id.StartsWith("D")).ToArray());
         }
 
-        public string[] GetAvailableRiders()
+        public Task<string[]> GetAvailableRiders()
         {
-            return Users.Where(id => id.StartsWith("R")).ToArray();
+            return Task.FromResult(Users.Where(id => id.StartsWith("R")).ToArray());
         }
 
     }

--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
@@ -12,7 +12,7 @@ namespace RideSharing
     // There is one UserEntity entity per user. 
     // The entity key is the UserId.
     [JsonObject(MemberSerialization.OptIn)]
-    public class UserEntity
+    public class UserEntity : IUserEntity
     {
         // the unique id for this user
         [JsonProperty]
@@ -45,14 +45,12 @@ namespace RideSharing
             return context.DispatchAsync<UserEntity>();
         }
 
-        // get the current state of this user
-        public UserEntity Get()
+        public Task<UserEntity> GetState()
         {
-            return this;
+            return Task.FromResult(this);
         }
 
-        // update the location / whether this user is looking for a match
-        public void SetLocation(int? newLocation)
+        public Task SetLocation(int? newLocation)
         {
             if (CurrentRide != null)
             {
@@ -60,18 +58,20 @@ namespace RideSharing
             }
 
             this.UpdateLocationAndNotify(newLocation);
+
+            return Task.CompletedTask;
         }
 
-        // update the location / whether this user is looking for a match
-        public void SetRide(RideInfo rideInfo)
+        public Task SetRide(RideInfo rideInfo)
         {
             CurrentRide = rideInfo;
 
             // this user is no longer looking for a match - clear location
             this.UpdateLocationAndNotify(null);
+
+            return Task.CompletedTask;
         }
 
-        // update the location / whether this user is looking for a match
         public void ClearRide(Guid rideId)
         {
             if (CurrentRide != null
@@ -80,10 +80,8 @@ namespace RideSharing
                 if (Entity.Current.EntityKey == CurrentRide.DriverId)
                 {
                     // forward signal to rider
-                    Entity.Current.SignalEntity(
-                        new EntityId(nameof(UserEntity), CurrentRide.RiderId),
-                        nameof(UserEntity.ClearRide),
-                        rideId);
+                    var riderProxy = Entity.Current.CreateEntityProxy<IUserEntity>(new EntityId(nameof(UserEntity), CurrentRide.RiderId));
+                    riderProxy.ClearRide(rideId);
                 }
 
                 CurrentRide = null;
@@ -109,12 +107,17 @@ namespace RideSharing
         {
             if (this.Location != null)
             {
-                Entity.Current.SignalEntity(
-                    new EntityId(nameof(RegionEntity), this.Location.Value.ToString()),
-                    available ? nameof(RegionEntity.AddUser) : nameof(RegionEntity.RemoveUser),
-                    this.UserId);
+                var regionProxy = Entity.Current.CreateEntityProxy<IRegionEntity>(new EntityId(nameof(RegionEntity), this.Location.Value.ToString()));
+
+                if (available)
+                {
+                    regionProxy.AddUser(this.UserId);
+                }
+                else
+                {
+                    regionProxy.RemoveUser(this.UserId);
+                }
             }
         }
-
     }
 }

--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/PublicRest/HttpSurface.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/PublicRest/HttpSurface.cs
@@ -56,7 +56,7 @@ namespace RideSharing
         {
             Authenticate(req, userId);
             var target = new EntityId(nameof(UserEntity), userId);
-            await client.SignalEntityAsync(target, nameof(UserEntity.SetLocation), (int?) null);
+            await client.SignalEntityAsync<IUserEntity>(target, proxy => proxy.SetLocation(null));
             return req.CreateResponse(HttpStatusCode.Accepted);
         }
 
@@ -78,7 +78,7 @@ namespace RideSharing
                 return req.CreateResponse(HttpStatusCode.BadRequest, "query must include a rideId Guid");
             }
             var driverEntity = new EntityId(nameof(UserEntity), driverId);
-            await client.SignalEntityAsync(driverEntity, nameof(UserEntity.ClearRide), rideId);
+            await client.SignalEntityAsync<IUserEntity>(driverEntity, proxy => proxy.ClearRide(rideId));
             return req.CreateResponse(HttpStatusCode.Accepted);
         }
 

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
+
 namespace Microsoft.Azure.WebJobs
 {
     /// <summary>
@@ -9,15 +12,26 @@ namespace Microsoft.Azure.WebJobs
     public static class DurableEntityProxyExtensions
     {
         /// <summary>
-        /// Create Entity Proxy.
+        /// Signals an entity to perform an operation.
         /// </summary>
-        /// <param name="client">orchestration client.</param>
-        /// <param name="entityId">Entity id.</param>
         /// <typeparam name="TEntityInterface">Entity interface.</typeparam>
-        /// <returns>Entity proxy.</returns>
-        public static TEntityInterface CreateEntityProxy<TEntityInterface>(this IDurableOrchestrationClient client, EntityId entityId)
+        /// <param name="client">orchestration client.</param>
+        /// <param name="entityId">The target entity.</param>
+        /// <param name="operation">A delegate that performs the desired operation on the entity.</param>
+        /// <returns>A task that completes when the message has been reliably enqueued.</returns>
+        public static Task SignalEntityAsync<TEntityInterface>(this IDurableOrchestrationClient client, EntityId entityId, Action<TEntityInterface> operation)
         {
-            return EntityProxyFactory.Create<TEntityInterface>(new OrchestrationClientProxy(client), entityId);
+            var proxyContext = new OrchestrationClientProxy(client);
+            var proxy = EntityProxyFactory.Create<TEntityInterface>(proxyContext, entityId);
+
+            operation(proxy);
+
+            if (proxyContext.SignalTask == null)
+            {
+                throw new InvalidOperationException("The operation action must perform an operation on the entity");
+            }
+
+            return proxyContext.SignalTask;
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationClientProxy.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/OrchestrationClientProxy.cs
@@ -15,19 +15,33 @@ namespace Microsoft.Azure.WebJobs
             this.client = client;
         }
 
+        internal Task SignalTask { get; private set; }
+
         public Task CallAsync(EntityId entityId, string operationName, object operationInput)
         {
-            throw new NotSupportedException();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+            return Task.CompletedTask;
         }
 
         public Task<TResult> CallAsync<TResult>(EntityId entityId, string operationName, object operationInput)
         {
-            throw new NotSupportedException();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+            return Task.FromResult<TResult>(default(TResult));
         }
 
         public void Signal(EntityId entityId, string operationName, object operationInput)
         {
-            this.client.SignalEntityAsync(entityId, operationName, operationInput).GetAwaiter().GetResult();
+            this.SignalAndStoreTask(entityId, operationName, operationInput);
+        }
+
+        private void SignalAndStoreTask(EntityId entityId, string operationName, object operationInput)
+        {
+            if (this.SignalTask != null)
+            {
+                throw new InvalidOperationException("The operation action must not perform more than one operation");
+            }
+
+            this.SignalTask = this.client.SignalEntityAsync(entityId, operationName, operationInput);
         }
     }
 }

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2270,14 +2270,15 @@
             Extension methods.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,Microsoft.Azure.WebJobs.EntityId)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.SignalEntityAsync``1(Microsoft.Azure.WebJobs.IDurableOrchestrationClient,Microsoft.Azure.WebJobs.EntityId,System.Action{``0})">
             <summary>
-            Create Entity Proxy.
+            Signals an entity to perform an operation.
             </summary>
-            <param name="client">orchestration client.</param>
-            <param name="entityId">Entity id.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
-            <returns>Entity proxy.</returns>
+            <param name="client">orchestration client.</param>
+            <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
+            <returns>A task that completes when the message has been reliably enqueued.</returns>
         </member>
         <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableOrchestrationContext,Microsoft.Azure.WebJobs.EntityId)">
             <summary>


### PR DESCRIPTION
I converted the samples (RideSharing and Chirper) to use the new proxy support, including the proposed client syntax in #1.

Overall, the code remained very similar and the experience was quite good.

Some observations:

- Creating the proxies can get a bit tedious, it is very verbose. For example: 

```csharp
var regionProxy = context.CreateEntityProxy<IRegionEntity>(new EntityId(nameof(RegionEntity), region.ToString()));
```
Perhaps we could offer shorter overloads.

- When adding the interface, it was not always immediately clear whether to return Task or void (i.e. whether an operation should be a call or a signal). Sometimes I had to go back and forth to get it right.

