### PR TITLE
Mitigate potential confusion about proxy operations inside entity context

### DIFF
--- a/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
+++ b/samples/v2/entitites-csharp/RideSharing/RideSharing/Entities/UserEntity.cs
@@ -80,8 +80,7 @@ namespace RideSharing
                 if (Entity.Current.EntityKey == CurrentRide.DriverId)
                 {
                     // forward signal to rider
-                    var riderProxy = Entity.Current.CreateEntityProxy<IUserEntity>(CurrentRide.RiderId);
-                    riderProxy.ClearRide(rideId);
+                    Entity.Current.SignalEntity<IUserEntity>(CurrentRide.RiderId, x => x.ClearRide(rideId));
                 }
 
                 CurrentRide = null;
@@ -107,15 +106,13 @@ namespace RideSharing
         {
             if (this.Location != null)
             {
-                var regionProxy = Entity.Current.CreateEntityProxy<IRegionEntity>(this.Location.Value.ToString());
-
                 if (available)
                 {
-                    regionProxy.AddUser(this.UserId);
+                    Entity.Current.SignalEntity<IRegionEntity>(this.Location.Value.ToString(), x => x.AddUser(this.UserId));
                 }
                 else
                 {
-                    regionProxy.RemoveUser(this.UserId);
+                    Entity.Current.SignalEntity<IRegionEntity>(this.Location.Value.ToString(), x => x.RemoveUser(this.UserId));
                 }
             }
         }

--- a/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
+++ b/src/WebJobs.Extensions.DurableTask/EntityScheduler/Proxy/DurableEntityProxyExtensions.cs
@@ -76,27 +76,27 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Create Entity Proxy.
+        /// Signals an entity to perform an operation.
         /// </summary>
         /// <param name="context">entity context.</param>
         /// <param name="entityKey">The target entity key.</param>
+        /// <param name="operation">A delegate that performs the desired operation on the entity.</param>
         /// <typeparam name="TEntityInterface">Entity interface.</typeparam>
-        /// <returns>Entity proxy.</returns>
-        public static TEntityInterface CreateEntityProxy<TEntityInterface>(this IDurableEntityContext context, string entityKey)
+        public static void SignalEntity<TEntityInterface>(this IDurableEntityContext context, string entityKey, Action<TEntityInterface> operation)
         {
-            return CreateEntityProxy<TEntityInterface>(context, new EntityId(ResolveEntityName<TEntityInterface>(), entityKey));
+            SignalEntity<TEntityInterface>(context, new EntityId(ResolveEntityName<TEntityInterface>(), entityKey), operation);
         }
 
         /// <summary>
-        /// Create Entity Proxy.
+        /// Signals an entity to perform an operation.
         /// </summary>
         /// <param name="context">entity context.</param>
         /// <param name="entityId">The target entity.</param>
+        /// <param name="operation">A delegate that performs the desired operation on the entity.</param>
         /// <typeparam name="TEntityInterface">Entity interface.</typeparam>
-        /// <returns>Entity proxy.</returns>
-        public static TEntityInterface CreateEntityProxy<TEntityInterface>(this IDurableEntityContext context, EntityId entityId)
+        public static void SignalEntity<TEntityInterface>(this IDurableEntityContext context, EntityId entityId, Action<TEntityInterface> operation)
         {
-            return EntityProxyFactory.Create<TEntityInterface>(new EntityContextProxy(context), entityId);
+            operation(EntityProxyFactory.Create<TEntityInterface>(new EntityContextProxy(context), entityId));
         }
 
         private static string ResolveEntityName<TEntityInterface>()

--- a/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
+++ b/src/WebJobs.Extensions.DurableTask/Microsoft.Azure.WebJobs.Extensions.DurableTask.xml
@@ -2308,23 +2308,23 @@
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
             <returns>Entity proxy.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableEntityContext,System.String)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.IDurableEntityContext,System.String,System.Action{``0})">
             <summary>
-            Create Entity Proxy.
+            Signals an entity to perform an operation.
             </summary>
             <param name="context">entity context.</param>
             <param name="entityKey">The target entity key.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
-            <returns>Entity proxy.</returns>
         </member>
-        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.CreateEntityProxy``1(Microsoft.Azure.WebJobs.IDurableEntityContext,Microsoft.Azure.WebJobs.EntityId)">
+        <member name="M:Microsoft.Azure.WebJobs.DurableEntityProxyExtensions.SignalEntity``1(Microsoft.Azure.WebJobs.IDurableEntityContext,Microsoft.Azure.WebJobs.EntityId,System.Action{``0})">
             <summary>
-            Create Entity Proxy.
+            Signals an entity to perform an operation.
             </summary>
             <param name="context">entity context.</param>
             <param name="entityId">The target entity.</param>
+            <param name="operation">A delegate that performs the desired operation on the entity.</param>
             <typeparam name="TEntityInterface">Entity interface.</typeparam>
-            <returns>Entity proxy.</returns>
         </member>
         <member name="T:Microsoft.Azure.WebJobs.EntityProxy">
             <summary>


### PR DESCRIPTION
This small change addresses the concern that users may be confused by the fact that proxies inside entities can not actually wait for an operation response. Calling an operation only produces a signal, i.e. it does not wait for the response, and does not return the result of the operation.

For example, inside an entity, we could write this which looks perfectly sensible but does not at all behave as expected:

```csharp
var proxy = Entity.Current.CreateEntityProxy<IUserEntity>(userId);
var state = await proxy.GetState();  // always returns null immediately
```

To make this less potentially confusing, I propose to replace `CreateEntityProxy` with `SignalEntity`, using the same pattern we have already in place for IDurableOrchestrationClient. 

Then we can signal entities like this:

```csharp
Entity.Current.SignalEntity<IUserEntity>(CurrentRide.RiderId, x => x.ClearRide(rideId));
```

This does not completely fix all issues. It is of course still possible to write nonsensical code such as 
```csharp
State state;
Entity.Current.SignalEntity<IUserEntity>(CurrentRide.RiderId, x => { state = x.GetState(); });
```
but at least now the names and structure of this code convey that this is something hacky and suspicious.
